### PR TITLE
Fix android notification not updating when editing pinned notification

### DIFF
--- a/app/src/main/java/dev/sasikanth/pinnit/editor/EditorScreenEffect.kt
+++ b/app/src/main/java/dev/sasikanth/pinnit/editor/EditorScreenEffect.kt
@@ -11,7 +11,12 @@ data class SetTitleAndContent(val title: String?, val content: String?) : Editor
 
 data class SaveNotificationAndCloseEditor(val title: String, val content: String?) : EditorScreenEffect()
 
-data class UpdateNotificationAndCloseEditor(val notificationUuid: UUID, val title: String, val content: String?) : EditorScreenEffect()
+data class UpdateNotificationAndCloseEditor(
+  val notificationUuid: UUID,
+  val title: String,
+  val content: String?,
+  val showAndroidNotification: Boolean
+) : EditorScreenEffect()
 
 object CloseEditor : EditorScreenEffect()
 

--- a/app/src/main/java/dev/sasikanth/pinnit/editor/EditorScreenEffectHandler.kt
+++ b/app/src/main/java/dev/sasikanth/pinnit/editor/EditorScreenEffectHandler.kt
@@ -61,11 +61,16 @@ class EditorScreenEffectHandler @AssistedInject constructor(
 
   private suspend fun updateNotificationAndCloseEditor(effect: UpdateNotificationAndCloseEditor) {
     val notification = notificationRepository.notification(effect.notificationUuid)
-    val updatedNotification = notification.copy(
-      title = effect.title,
-      content = effect.content
+    val updatedNotification = notificationRepository.updateNotification(
+      notification.copy(
+        title = effect.title,
+        content = effect.content
+      )
     )
-    notificationRepository.updateNotification(updatedNotification)
+
+    if (effect.showAndroidNotification) {
+      notificationUtil.showNotification(updatedNotification)
+    }
     viewEffectConsumer.accept(CloseEditorView)
   }
 

--- a/app/src/main/java/dev/sasikanth/pinnit/editor/EditorScreenUpdate.kt
+++ b/app/src/main/java/dev/sasikanth/pinnit/editor/EditorScreenUpdate.kt
@@ -38,7 +38,12 @@ class EditorScreenUpdate : Update<EditorScreenModel, EditorScreenEvent, EditorSc
     val effect = if (model.notification == null) {
       SaveNotificationAndCloseEditor(model.title!!, model.content)
     } else {
-      UpdateNotificationAndCloseEditor(model.notification.uuid, model.title!!, model.content)
+      UpdateNotificationAndCloseEditor(
+        notificationUuid = model.notification.uuid,
+        title = model.title!!,
+        content = model.content,
+        showAndroidNotification = model.notification.isPinned
+      )
     }
 
     return dispatch(setOf(effect))

--- a/app/src/test/java/dev/sasikanth/pinnit/editor/EditorScreenEffectHandlerTest.kt
+++ b/app/src/test/java/dev/sasikanth/pinnit/editor/EditorScreenEffectHandlerTest.kt
@@ -120,12 +120,20 @@ class EditorScreenEffectHandlerTest {
     whenever(repository.updateNotification(updatedNotification)) doReturn updatedNotification
 
     // when
-    connection.accept(UpdateNotificationAndCloseEditor(notificationUuid, updatedTitle, null))
+    connection.accept(UpdateNotificationAndCloseEditor(
+      notificationUuid = notificationUuid,
+      title = updatedTitle,
+      content = null,
+      showAndroidNotification = true
+    ))
 
     // then
     verify(repository).notification(notificationUuid)
     verify(repository).updateNotification(updatedNotification)
     verifyNoMoreInteractions(repository)
+
+    verify(notificationUtil).showNotification(updatedNotification)
+    verifyNoMoreInteractions(notificationUtil)
 
     consumer.assertValues()
     viewEffectConsumer.assertValues(CloseEditorView)

--- a/app/src/test/java/dev/sasikanth/pinnit/editor/EditorScreenUpdateTest.kt
+++ b/app/src/test/java/dev/sasikanth/pinnit/editor/EditorScreenUpdateTest.kt
@@ -87,8 +87,13 @@ class EditorScreenUpdateTest {
 
   @Test
   fun `when save is clicked and notification is present, then update the notification`() {
-    val model = defaultModel
-      .notificationLoaded(notification)
+    val pinnedNotificationUuid = UUID.fromString("ad9ca7be-55a6-492c-bd5a-4e6d5860e973")
+    val pinnedNotification = TestData.notification(
+      uuid = pinnedNotificationUuid,
+      isPinned = true
+    )
+    val model = EditorScreenModel.default(pinnedNotificationUuid, null)
+      .notificationLoaded(pinnedNotification)
       .titleChanged("Title")
       .contentChanged("Content")
 
@@ -98,7 +103,14 @@ class EditorScreenUpdateTest {
       .then(
         assertThatNext(
           hasNoModel(),
-          hasEffects(UpdateNotificationAndCloseEditor(notificationUuid, model.title!!, model.content) as EditorScreenEffect)
+          hasEffects(
+            UpdateNotificationAndCloseEditor(
+              notificationUuid = pinnedNotificationUuid,
+              title = model.title!!,
+              content = model.content,
+              showAndroidNotification = true
+            ) as EditorScreenEffect
+          )
         )
       )
   }


### PR DESCRIPTION
We have stopped pinning notifications when editing notifications. So it caused issues with Android notification not being updated when editing a already pinned notification that shows Android notification. In order to fix that we are only showing Android notification again when updating an pinned notification.