### PR TITLE
Fix Don't kill my app links

### DIFF
--- a/app/src/main/java/dev/sasikanth/pinnit/oemwarning/OemWarningDialog.kt
+++ b/app/src/main/java/dev/sasikanth/pinnit/oemwarning/OemWarningDialog.kt
@@ -14,12 +14,13 @@ import androidx.fragment.app.FragmentManager
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dev.sasikanth.pinnit.R
 import kotlinx.android.synthetic.main.pinnit_oem_warning_dialog.*
+import java.util.Locale
 
 class OemWarningDialog : DialogFragment() {
 
   companion object {
     private const val TAG = "OEM_WARNING_DIALOG"
-    private val DONT_KILL_MY_APP_LINK = "https://dontkillmyapp.com/${Build.BRAND}"
+    private val DONT_KILL_MY_APP_LINK = "https://dontkillmyapp.com/${Build.BRAND.toLowerCase(Locale.US)}"
 
     fun show(fragmentManager: FragmentManager) {
       OemWarningDialog()


### PR DESCRIPTION
Build.BRAND can return brand names where the first character is uppercase.
The path on the URLs need to lower case.

Valid URL: https://dontkillmyapp.com/nokia
Invalid URL (404): https://dontkillmyapp.com/Nokia