### PR TITLE
Attempt to fix overlapping notifications issue

### DIFF
--- a/app/src/main/java/dev/sasikanth/pinnit/notifications/NotificationsScreen.kt
+++ b/app/src/main/java/dev/sasikanth/pinnit/notifications/NotificationsScreen.kt
@@ -187,11 +187,15 @@ class NotificationsScreen : Fragment(R.layout.fragment_notifications), Notificat
     } else {
       val backward = MaterialSharedAxis(MaterialSharedAxis.Y, false).apply {
         duration = 300
+        addTarget(R.id.notificationsRoot)
+        addTarget(R.id.editorRoot)
       }
       reenterTransition = backward
 
       val forward = MaterialSharedAxis(MaterialSharedAxis.Y, true).apply {
         duration = 300
+        addTarget(R.id.notificationsRoot)
+        addTarget(R.id.editorRoot)
       }
       exitTransition = forward
       findNavController().navigate(navDirections)


### PR DESCRIPTION
Adds `MaterialSharedAxis` targets to prevent transition running on every view in the Fragment's layout.

Appears to fix the issue from on-device testing on Pixel 5 API 30, but needs a thorough test.

Sources:
- https://github.com/material-components/material-components-android/commit/d4d0dcdbc6094e2b94b99c42d36c1fdfb1af8760
- https://github.com/material-components/material-components-android/blob/master/catalog/java/io/material/catalog/transition/TransitionSharedAxisDemoFragment.java#L92