### PR TITLE
Migrate kotlin synthetic view accessors to view binding

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,6 +54,7 @@ android {
   }
   buildFeatures {
     compose true
+    viewBinding true
   }
   compileOptions {
     coreLibraryDesugaringEnabled true

--- a/app/src/main/java/dev/sasikanth/pinnit/SplashActivity.kt
+++ b/app/src/main/java/dev/sasikanth/pinnit/SplashActivity.kt
@@ -9,7 +9,7 @@ import androidx.vectordrawable.graphics.drawable.Animatable2Compat
 import androidx.vectordrawable.graphics.drawable.AnimatedVectorDrawableCompat
 import dev.chrisbanes.insetter.setEdgeToEdgeSystemUiFlags
 import dev.sasikanth.pinnit.activity.MainActivity
-import kotlinx.android.synthetic.main.activity_splash.*
+import dev.sasikanth.pinnit.databinding.ActivitySplashBinding
 
 class SplashActivity : AppCompatActivity() {
 
@@ -24,18 +24,23 @@ class SplashActivity : AppCompatActivity() {
 
   private var animatedWelcomeImage: AnimatedVectorDrawableCompat? = null
 
+  private lateinit var binding: ActivitySplashBinding
+
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
-    setContentView(R.layout.activity_splash)
+    binding = ActivitySplashBinding.inflate(layoutInflater)
+    setContentView(binding.root)
 
-    rootView.setEdgeToEdgeSystemUiFlags()
+    binding.rootView.setEdgeToEdgeSystemUiFlags()
 
     animatedWelcomeImage = AnimatedVectorDrawableCompat.create(this, R.drawable.avd_pin_welcome)
 
-    welcomeImage.setImageDrawable(animatedWelcomeImage)
-    welcomeImage.doOnLayout {
-      animatedWelcomeImage?.start()
-      animatedWelcomeImage?.registerAnimationCallback(animationCallback)
+    binding.welcomeImage.apply {
+      setImageDrawable(animatedWelcomeImage)
+      doOnLayout {
+        animatedWelcomeImage?.start()
+        animatedWelcomeImage?.registerAnimationCallback(animationCallback)
+      }
     }
   }
 

--- a/app/src/main/java/dev/sasikanth/pinnit/about/AboutBottomSheet.kt
+++ b/app/src/main/java/dev/sasikanth/pinnit/about/AboutBottomSheet.kt
@@ -12,9 +12,9 @@ import androidx.fragment.app.FragmentManager
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dev.sasikanth.pinnit.BuildConfig
 import dev.sasikanth.pinnit.R
+import dev.sasikanth.pinnit.databinding.SheetAboutBinding
 import dev.sasikanth.pinnit.oemwarning.OemWarningDialog
 import dev.sasikanth.pinnit.oemwarning.shouldShowWarningForOEM
-import kotlinx.android.synthetic.main.sheet_about.*
 
 class AboutBottomSheet : BottomSheetDialogFragment() {
 
@@ -27,8 +27,12 @@ class AboutBottomSheet : BottomSheetDialogFragment() {
     }
   }
 
+  private var _binding: SheetAboutBinding? = null
+  private val binding get() = _binding!!
+
   override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-    return inflater.inflate(R.layout.sheet_about, container, false)
+    _binding = SheetAboutBinding.inflate(layoutInflater, container, false)
+    return _binding?.root
   }
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -36,19 +40,24 @@ class AboutBottomSheet : BottomSheetDialogFragment() {
 
     setAppVersion()
 
-    contactSupportButton.setOnClickListener { sendSupportEmail() }
-    sourceCodeButton.setOnClickListener { openGitHubProject() }
+    binding.contactSupportButton.setOnClickListener { sendSupportEmail() }
+    binding.sourceCodeButton.setOnClickListener { openGitHubProject() }
 
     setupShowOemWarning()
+  }
+
+  override fun onDestroyView() {
+    _binding = null
+    super.onDestroyView()
   }
 
   private fun setupShowOemWarning() {
     val brandName = Build.BRAND
     val shouldShowOemWarning = shouldShowWarningForOEM(brandName)
-    dividerView.isVisible = shouldShowOemWarning
-    oemWarningButton.isVisible = shouldShowOemWarning
+    binding.dividerView.isVisible = shouldShowOemWarning
+    binding.oemWarningButton.isVisible = shouldShowOemWarning
 
-    oemWarningButton.setOnClickListener {
+    binding.oemWarningButton.setOnClickListener {
       dismiss()
       OemWarningDialog.show(requireActivity().supportFragmentManager)
     }
@@ -56,7 +65,7 @@ class AboutBottomSheet : BottomSheetDialogFragment() {
 
   private fun setAppVersion() {
     val versionName = BuildConfig.VERSION_NAME
-    appVersionTextView.text = getString(R.string.app_version, versionName)
+    binding.appVersionTextView.text = getString(R.string.app_version, versionName)
   }
 
   private fun sendSupportEmail() {

--- a/app/src/main/java/dev/sasikanth/pinnit/activity/MainActivity.kt
+++ b/app/src/main/java/dev/sasikanth/pinnit/activity/MainActivity.kt
@@ -13,7 +13,6 @@ import dev.sasikanth.pinnit.R
 import dev.sasikanth.pinnit.data.preferences.AppPreferences
 import dev.sasikanth.pinnit.databinding.ActivityMainBinding
 import dev.sasikanth.pinnit.di.injector
-import dev.sasikanth.pinnit.editor.EditorScreenArgs
 import dev.sasikanth.pinnit.oemwarning.OemWarningDialog
 import dev.sasikanth.pinnit.oemwarning.shouldShowWarningForOEM
 import dev.sasikanth.pinnit.utils.DispatcherProvider
@@ -31,28 +30,6 @@ class MainActivity : AppCompatActivity() {
   lateinit var dispatcherProvider: DispatcherProvider
 
   private var navController: NavController? = null
-  private val onNavDestinationChangeListener = NavController.OnDestinationChangedListener { _, destination, arguments ->
-    binding.appBarLayout.setExpanded(true, true)
-    when (destination.id) {
-      R.id.notificationsScreen -> {
-        binding.toolbarTitleTextView.text = getString(R.string.toolbar_title_notifications)
-      }
-      R.id.editorScreen -> {
-        if (arguments != null) {
-          // If there is a notification present
-          // we will be showing the edit title or else we show
-          // create title
-          val editorScreenArgs = EditorScreenArgs.fromBundle(arguments)
-          val toolbarTitle = if (editorScreenArgs.notificationUuid == null) {
-            getString(R.string.toolbar_title_create)
-          } else {
-            getString(R.string.toolbar_title_edit)
-          }
-          binding.toolbarTitleTextView.text = toolbarTitle
-        }
-      }
-    }
-  }
 
   private lateinit var binding: ActivityMainBinding
 
@@ -71,7 +48,6 @@ class MainActivity : AppCompatActivity() {
 
     val navHostFragment = supportFragmentManager.findFragmentById(R.id.nav_host_fragment_container) as NavHostFragment
     navController = navHostFragment.navController
-    navController?.addOnDestinationChangedListener(onNavDestinationChangeListener)
 
     lifecycleScope.launchWhenResumed {
       val isOemWarningDialogShown = withContext(dispatcherProvider.io) {
@@ -95,7 +71,6 @@ class MainActivity : AppCompatActivity() {
   }
 
   override fun onDestroy() {
-    navController?.removeOnDestinationChangedListener(onNavDestinationChangeListener)
     navController = null
     super.onDestroy()
   }

--- a/app/src/main/java/dev/sasikanth/pinnit/activity/MainActivity.kt
+++ b/app/src/main/java/dev/sasikanth/pinnit/activity/MainActivity.kt
@@ -41,10 +41,6 @@ class MainActivity : AppCompatActivity() {
     setContentView(binding.root)
 
     binding.mainRoot.setEdgeToEdgeSystemUiFlags()
-    binding.toolbar.apply {
-      applySystemWindowInsetsToPadding(top = true, right = true, left = true)
-      setSupportActionBar(this)
-    }
 
     val navHostFragment = supportFragmentManager.findFragmentById(R.id.nav_host_fragment_container) as NavHostFragment
     navController = navHostFragment.navController

--- a/app/src/main/java/dev/sasikanth/pinnit/editor/EditorScreen.kt
+++ b/app/src/main/java/dev/sasikanth/pinnit/editor/EditorScreen.kt
@@ -43,7 +43,6 @@ import dev.sasikanth.pinnit.utils.UserClock
 import dev.sasikanth.pinnit.utils.UtcClock
 import dev.sasikanth.pinnit.utils.resolveColor
 import dev.sasikanth.pinnit.utils.reverse
-import kotlinx.android.synthetic.main.activity_main.*
 import kotlinx.android.synthetic.main.fragment_notification_editor.*
 import kotlinx.android.synthetic.main.view_schedule.*
 import kotlinx.android.synthetic.main.view_schedule.view.*
@@ -174,6 +173,15 @@ class EditorScreen : Fragment(R.layout.fragment_notification_editor), EditorScre
 
     viewModelObservers()
 
+    toolbar.applySystemWindowInsetsToPadding(top = true, left = true, right = true)
+
+    val toolbarTitle = if (args.notificationUuid == null) {
+      getString(R.string.toolbar_title_create)
+    } else {
+      getString(R.string.toolbar_title_edit)
+    }
+    toolbarTitleTextView.text = toolbarTitle
+
     if (editorTransition is ContainerTransform) {
       editorRoot.transitionName = (editorTransition as ContainerTransform).transitionName
     }
@@ -225,18 +233,18 @@ class EditorScreen : Fragment(R.layout.fragment_notification_editor), EditorScre
   }
 
   private fun configBottomBar() {
-    requireActivity().bottomBar.setNavigationIcon(R.drawable.ic_arrow_back)
-    requireActivity().bottomBar.setContentActionEnabled(false)
-    requireActivity().bottomBar.setContentActionText(contentActionText = null)
-    requireActivity().bottomBar.setActionIcon(null)
+    bottomBar.setNavigationIcon(R.drawable.ic_arrow_back)
+    bottomBar.setContentActionEnabled(false)
+    bottomBar.setContentActionText(contentActionText = null)
+    bottomBar.setActionIcon(null)
 
-    requireActivity().bottomBar.setNavigationOnClickListener {
+    bottomBar.setNavigationOnClickListener {
       viewModel.dispatchEvent(BackClicked)
     }
-    requireActivity().bottomBar.setContentActionOnClickListener {
+    bottomBar.setContentActionOnClickListener {
       viewModel.dispatchEvent(SaveClicked)
     }
-    requireActivity().bottomBar.setActionOnClickListener {
+    bottomBar.setActionOnClickListener {
       viewModel.dispatchEvent(DeleteNotificationClicked)
     }
   }
@@ -280,27 +288,27 @@ class EditorScreen : Fragment(R.layout.fragment_notification_editor), EditorScre
   }
 
   override fun enableSave() {
-    requireActivity().bottomBar.setContentActionEnabled(true)
+    bottomBar.setContentActionEnabled(true)
   }
 
   override fun disableSave() {
-    requireActivity().bottomBar.setContentActionEnabled(false)
+    bottomBar.setContentActionEnabled(false)
   }
 
   override fun renderSaveActionButtonText() {
-    requireActivity().bottomBar.setContentActionText(R.string.save)
+    bottomBar.setContentActionText(R.string.save)
   }
 
   override fun renderSaveAndPinActionButtonText() {
-    requireActivity().bottomBar.setContentActionText(R.string.save_and_pin)
+    bottomBar.setContentActionText(R.string.save_and_pin)
   }
 
   override fun showDeleteButton() {
-    requireActivity().bottomBar.setActionIcon(R.drawable.ic_pinnit_delete)
+    bottomBar.setActionIcon(R.drawable.ic_pinnit_delete)
   }
 
   override fun hideDeleteButton() {
-    requireActivity().bottomBar.setActionIcon(null)
+    bottomBar.setActionIcon(null)
   }
 
   override fun showScheduleView() {

--- a/app/src/main/java/dev/sasikanth/pinnit/editor/EditorScreen.kt
+++ b/app/src/main/java/dev/sasikanth/pinnit/editor/EditorScreen.kt
@@ -3,8 +3,10 @@ package dev.sasikanth.pinnit.editor
 import android.content.Context
 import android.os.Bundle
 import android.text.util.Linkify
+import android.view.LayoutInflater
 import android.view.View
 import android.view.View.NO_ID
+import android.view.ViewGroup
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
 import androidx.activity.addCallback
@@ -33,6 +35,7 @@ import dev.chrisbanes.insetter.applySystemWindowInsetsToPadding
 import dev.sasikanth.pinnit.R
 import dev.sasikanth.pinnit.data.Schedule
 import dev.sasikanth.pinnit.data.ScheduleType
+import dev.sasikanth.pinnit.databinding.FragmentNotificationEditorBinding
 import dev.sasikanth.pinnit.di.DateTimeFormat
 import dev.sasikanth.pinnit.di.DateTimeFormat.Type.ScheduleDateFormat
 import dev.sasikanth.pinnit.di.DateTimeFormat.Type.ScheduleTimeFormat
@@ -43,9 +46,6 @@ import dev.sasikanth.pinnit.utils.UserClock
 import dev.sasikanth.pinnit.utils.UtcClock
 import dev.sasikanth.pinnit.utils.resolveColor
 import dev.sasikanth.pinnit.utils.reverse
-import kotlinx.android.synthetic.main.fragment_notification_editor.*
-import kotlinx.android.synthetic.main.view_schedule.*
-import kotlinx.android.synthetic.main.view_schedule.view.*
 import me.saket.bettermovementmethod.BetterLinkMovementMethod
 import java.time.Instant
 import java.time.LocalDate
@@ -54,7 +54,7 @@ import java.time.format.DateTimeFormatter
 import java.util.UUID
 import javax.inject.Inject
 
-class EditorScreen : Fragment(R.layout.fragment_notification_editor), EditorScreenUi {
+class EditorScreen : Fragment(), EditorScreenUi {
 
   @Inject
   lateinit var effectHandler: EditorScreenEffectHandler.Factory
@@ -126,6 +126,10 @@ class EditorScreen : Fragment(R.layout.fragment_notification_editor), EditorScre
     SeekableAnimatedVectorDrawable.create(requireContext(), R.drawable.avd_add_to_delete)!!
   }
 
+  private var _binding: FragmentNotificationEditorBinding? = null
+  private val binding get() = _binding!!
+  private val scheduleViewBinding get() = binding.scheduleView
+
   override fun onAttach(context: Context) {
     super.onAttach(context)
     injector.inject(this)
@@ -142,6 +146,42 @@ class EditorScreen : Fragment(R.layout.fragment_notification_editor), EditorScre
     requireActivity().onBackPressedDispatcher.addCallback(this) {
       viewModel.dispatchEvent(BackClicked)
     }
+  }
+
+  override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+    _binding = FragmentNotificationEditorBinding.inflate(layoutInflater, container, false)
+    return _binding?.root
+  }
+
+  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    super.onViewCreated(view, savedInstanceState)
+
+    configBottomBar()
+    configTitleEditText()
+    configContentEditText()
+
+    viewModelObservers()
+
+    binding.toolbar.applySystemWindowInsetsToPadding(top = true, left = true, right = true)
+
+    val toolbarTitle = if (args.notificationUuid == null) {
+      getString(R.string.toolbar_title_create)
+    } else {
+      getString(R.string.toolbar_title_edit)
+    }
+    binding.toolbarTitleTextView.text = toolbarTitle
+
+    if (editorTransition is ContainerTransform) {
+      binding.editorRoot.transitionName = (editorTransition as ContainerTransform).transitionName
+    }
+    binding.editorScrollView.applySystemWindowInsetsToPadding(bottom = true, left = true, right = true)
+
+    scheduleViewBinding.addRemoveScheduleButton.setImageDrawable(seekableAvd)
+  }
+
+  override fun onDestroyView() {
+    _binding = null
+    super.onDestroyView()
   }
 
   private fun containerTransformTransition() {
@@ -162,32 +202,6 @@ class EditorScreen : Fragment(R.layout.fragment_notification_editor), EditorScre
       duration = 300
     }
     returnTransition = backward
-  }
-
-  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-    super.onViewCreated(view, savedInstanceState)
-
-    configBottomBar()
-    configTitleEditText()
-    configContentEditText()
-
-    viewModelObservers()
-
-    toolbar.applySystemWindowInsetsToPadding(top = true, left = true, right = true)
-
-    val toolbarTitle = if (args.notificationUuid == null) {
-      getString(R.string.toolbar_title_create)
-    } else {
-      getString(R.string.toolbar_title_edit)
-    }
-    toolbarTitleTextView.text = toolbarTitle
-
-    if (editorTransition is ContainerTransform) {
-      editorRoot.transitionName = (editorTransition as ContainerTransform).transitionName
-    }
-    editorScrollView.applySystemWindowInsetsToPadding(bottom = true, left = true, right = true)
-
-    scheduleView.addRemoveScheduleButton.setImageDrawable(seekableAvd)
   }
 
   private fun viewModelObservers() {
@@ -233,82 +247,82 @@ class EditorScreen : Fragment(R.layout.fragment_notification_editor), EditorScre
   }
 
   private fun configBottomBar() {
-    bottomBar.setNavigationIcon(R.drawable.ic_arrow_back)
-    bottomBar.setContentActionEnabled(false)
-    bottomBar.setContentActionText(contentActionText = null)
-    bottomBar.setActionIcon(null)
+    binding.bottomBar.setNavigationIcon(R.drawable.ic_arrow_back)
+    binding.bottomBar.setContentActionEnabled(false)
+    binding.bottomBar.setContentActionText(contentActionText = null)
+    binding.bottomBar.setActionIcon(null)
 
-    bottomBar.setNavigationOnClickListener {
+    binding.bottomBar.setNavigationOnClickListener {
       viewModel.dispatchEvent(BackClicked)
     }
-    bottomBar.setContentActionOnClickListener {
+    binding.bottomBar.setContentActionOnClickListener {
       viewModel.dispatchEvent(SaveClicked)
     }
-    bottomBar.setActionOnClickListener {
+    binding.bottomBar.setActionOnClickListener {
       viewModel.dispatchEvent(DeleteNotificationClicked)
     }
   }
 
   private fun configTitleEditText() {
-    titleEditText.doAfterTextChanged { viewModel.dispatchEvent(TitleChanged(it?.toString().orEmpty())) }
-    titleEditText.imeOptions = EditorInfo.IME_ACTION_NEXT
-    titleEditText.inputType = EditorInfo.TYPE_TEXT_FLAG_CAP_SENTENCES or EditorInfo.TYPE_TEXT_FLAG_MULTI_LINE
-    titleEditText.setHorizontallyScrolling(false)
-    titleEditText.maxLines = 5
+    binding.titleEditText.doAfterTextChanged { viewModel.dispatchEvent(TitleChanged(it?.toString().orEmpty())) }
+    binding.titleEditText.imeOptions = EditorInfo.IME_ACTION_NEXT
+    binding.titleEditText.inputType = EditorInfo.TYPE_TEXT_FLAG_CAP_SENTENCES or EditorInfo.TYPE_TEXT_FLAG_MULTI_LINE
+    binding.titleEditText.setHorizontallyScrolling(false)
+    binding.titleEditText.maxLines = 5
   }
 
   private fun configContentEditText() {
-    contentEditText.movementMethod = BetterLinkMovementMethod.getInstance()
-    contentEditText.doAfterTextChanged { viewModel.dispatchEvent(ContentChanged(it?.toString())) }
+    binding.contentEditText.movementMethod = BetterLinkMovementMethod.getInstance()
+    binding.contentEditText.doAfterTextChanged { viewModel.dispatchEvent(ContentChanged(it?.toString())) }
   }
 
   private fun setTitleText(title: String?) {
-    titleEditText.setText(title)
-    titleEditText.requestFocus()
-    titleEditText.setSelection(title?.length ?: 0)
+    binding.titleEditText.setText(title)
+    binding.titleEditText.requestFocus()
+    binding.titleEditText.setSelection(title?.length ?: 0)
 
-    titleEditText.postDelayed({
+    binding.titleEditText.postDelayed({
       val imm = requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager?
-      imm?.showSoftInput(titleEditText, InputMethodManager.SHOW_IMPLICIT)
+      imm?.showSoftInput(binding.titleEditText, InputMethodManager.SHOW_IMPLICIT)
     }, 250)
   }
 
   private fun setContentText(content: String?) {
-    contentEditText.setText(content)
-    Linkify.addLinks(contentEditText, Linkify.WEB_URLS)
+    binding.contentEditText.setText(content)
+    Linkify.addLinks(binding.contentEditText, Linkify.WEB_URLS)
   }
 
   private fun closeEditor() {
     if (findNavController().currentDestination?.id == R.id.editorScreen) {
       val imm = requireContext().getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager?
-      imm?.hideSoftInputFromWindow(titleEditText.windowToken, 0)
+      imm?.hideSoftInputFromWindow(binding.titleEditText.windowToken, 0)
 
       findNavController().navigateUp()
     }
   }
 
   override fun enableSave() {
-    bottomBar.setContentActionEnabled(true)
+    binding.bottomBar.setContentActionEnabled(true)
   }
 
   override fun disableSave() {
-    bottomBar.setContentActionEnabled(false)
+    binding.bottomBar.setContentActionEnabled(false)
   }
 
   override fun renderSaveActionButtonText() {
-    bottomBar.setContentActionText(R.string.save)
+    binding.bottomBar.setContentActionText(R.string.save)
   }
 
   override fun renderSaveAndPinActionButtonText() {
-    bottomBar.setContentActionText(R.string.save_and_pin)
+    binding.bottomBar.setContentActionText(R.string.save_and_pin)
   }
 
   override fun showDeleteButton() {
-    bottomBar.setActionIcon(R.drawable.ic_pinnit_delete)
+    binding.bottomBar.setActionIcon(R.drawable.ic_pinnit_delete)
   }
 
   override fun hideDeleteButton() {
-    bottomBar.setActionIcon(null)
+    binding.bottomBar.setActionIcon(null)
   }
 
   override fun showScheduleView() {
@@ -317,48 +331,48 @@ class EditorScreen : Fragment(R.layout.fragment_notification_editor), EditorScre
       seekableAvd.currentPlayTime = seekableAvd.totalDuration
     }
 
-    scheduleView.addRemoveScheduleButton.setOnClickListener {
+    scheduleViewBinding.addRemoveScheduleButton.setOnClickListener {
       seekableAvd.reverse()
       viewModel.dispatchEvent(RemoveScheduleClicked)
     }
 
-    scheduleView.scheduleHeadingTextView.isGone = true
-    scheduleView.scheduleDateButton.isVisible = true
-    scheduleView.scheduleTimeButton.isVisible = true
-    scheduleView.repeatEveryCheckBox.isVisible = true
-    scheduleView.repeatEveryButtonGroup.isVisible = true
+    scheduleViewBinding.scheduleHeadingTextView.isGone = true
+    scheduleViewBinding.scheduleDateButton.isVisible = true
+    scheduleViewBinding.scheduleTimeButton.isVisible = true
+    scheduleViewBinding.repeatEveryCheckBox.isVisible = true
+    scheduleViewBinding.repeatEveryButtonGroup.isVisible = true
   }
 
   override fun renderScheduleDateTime(scheduleDate: LocalDate, scheduleTime: LocalTime) {
-    scheduleDateButton.text = scheduleDateFormatter.format(scheduleDate)
-    scheduleTimeButton.text = scheduleTimeFormatter.format(scheduleTime)
+    scheduleViewBinding.scheduleDateButton.text = scheduleDateFormatter.format(scheduleDate)
+    scheduleViewBinding.scheduleTimeButton.text = scheduleTimeFormatter.format(scheduleTime)
 
-    scheduleView.scheduleDateButton.setOnClickListener {
+    scheduleViewBinding.scheduleDateButton.setOnClickListener {
       viewModel.dispatchEvent(ScheduleDateClicked)
     }
 
-    scheduleView.scheduleTimeButton.setOnClickListener {
+    scheduleViewBinding.scheduleTimeButton.setOnClickListener {
       viewModel.dispatchEvent(ScheduleTimeClicked)
     }
   }
 
   override fun renderScheduleRepeat(scheduleType: ScheduleType?, hasValidScheduleResult: Boolean) {
-    scheduleView.repeatEveryButtonGroup.clearChecked()
+    scheduleViewBinding.repeatEveryButtonGroup.clearChecked()
     // To avoid any un-necessary even triggers of schedule type change
     // when schedule repeat is not set. so we are removing listeners on every model changes
     // and resetting it if schedule type is available.
-    scheduleView.repeatEveryButtonGroup.clearOnButtonCheckedListeners()
+    scheduleViewBinding.repeatEveryButtonGroup.clearOnButtonCheckedListeners()
 
     val hasScheduleType = scheduleType != null
 
-    scheduleView.repeatEveryCheckBox.isChecked = hasScheduleType
+    scheduleViewBinding.repeatEveryCheckBox.isChecked = hasScheduleType
 
-    scheduleView.repeatEveryCheckBox.isEnabled = hasValidScheduleResult
-    scheduleView.repeatDailyButton.isEnabled = hasScheduleType && hasValidScheduleResult
-    scheduleView.repeatWeeklyButton.isEnabled = hasScheduleType && hasValidScheduleResult
-    scheduleView.repeatMonthlyButton.isEnabled = hasScheduleType && hasValidScheduleResult
+    scheduleViewBinding.repeatEveryCheckBox.isEnabled = hasValidScheduleResult
+    scheduleViewBinding.repeatDailyButton.isEnabled = hasScheduleType && hasValidScheduleResult
+    scheduleViewBinding.repeatWeeklyButton.isEnabled = hasScheduleType && hasValidScheduleResult
+    scheduleViewBinding.repeatMonthlyButton.isEnabled = hasScheduleType && hasValidScheduleResult
 
-    scheduleView.repeatEveryCheckBox.setOnCheckedChangeListener { _, isChecked ->
+    scheduleViewBinding.repeatEveryCheckBox.setOnCheckedChangeListener { _, isChecked ->
       if (isChecked.not())
         viewModel.dispatchEvent(ScheduleRepeatUnchecked)
       else
@@ -366,8 +380,8 @@ class EditorScreen : Fragment(R.layout.fragment_notification_editor), EditorScre
     }
 
     if (scheduleType != null) {
-      scheduleView.repeatEveryButtonGroup.check(scheduleTypeToButtonId.getValue(scheduleType))
-      scheduleView.repeatEveryButtonGroup.addOnButtonCheckedListener { _, checkedId, isChecked ->
+      scheduleViewBinding.repeatEveryButtonGroup.check(scheduleTypeToButtonId.getValue(scheduleType))
+      scheduleViewBinding.repeatEveryButtonGroup.addOnButtonCheckedListener { _, checkedId, isChecked ->
         if (checkedId != NO_ID && isChecked) {
           viewModel.dispatchEvent(ScheduleTypeChanged(buttonIdToScheduleType.getValue(checkedId)))
         }
@@ -376,16 +390,16 @@ class EditorScreen : Fragment(R.layout.fragment_notification_editor), EditorScre
   }
 
   override fun showScheduleWarning() {
-    scheduleView.scheduleWarningContainer.isVisible = true
-    scheduleView.scheduleWarningTextView.text = requireContext().getString(R.string.editor_schedule_past_warning)
+    scheduleViewBinding.scheduleWarningContainer.isVisible = true
+    scheduleViewBinding.scheduleWarningTextView.text = requireContext().getString(R.string.editor_schedule_past_warning)
   }
 
   override fun hideScheduleWarning() {
-    scheduleView.scheduleWarningContainer.isGone = true
+    scheduleViewBinding.scheduleWarningContainer.isGone = true
   }
 
   override fun hideScheduleView() {
-    scheduleView.addRemoveScheduleButton.setOnClickListener {
+    scheduleViewBinding.addRemoveScheduleButton.setOnClickListener {
       // Start animating the add icon to delete icon
       seekableAvd.start()
 
@@ -393,18 +407,18 @@ class EditorScreen : Fragment(R.layout.fragment_notification_editor), EditorScre
       viewModel.dispatchEvent(AddScheduleClicked(schedule))
     }
 
-    scheduleView.scheduleDateButton.isGone = true
-    scheduleView.scheduleTimeButton.isGone = true
+    scheduleViewBinding.scheduleDateButton.isGone = true
+    scheduleViewBinding.scheduleTimeButton.isGone = true
 
-    scheduleView.scheduleWarningContainer.isGone = true
+    scheduleViewBinding.scheduleWarningContainer.isGone = true
 
-    scheduleView.repeatEveryCheckBox.isGone = true
-    scheduleView.repeatEveryCheckBox.setOnCheckedChangeListener(null)
+    scheduleViewBinding.repeatEveryCheckBox.isGone = true
+    scheduleViewBinding.repeatEveryCheckBox.setOnCheckedChangeListener(null)
 
-    scheduleView.repeatEveryButtonGroup.isGone = true
-    scheduleView.repeatEveryButtonGroup.clearOnButtonCheckedListeners()
+    scheduleViewBinding.repeatEveryButtonGroup.isGone = true
+    scheduleViewBinding.repeatEveryButtonGroup.clearOnButtonCheckedListeners()
 
-    scheduleView.scheduleHeadingTextView.isVisible = true
+    scheduleViewBinding.scheduleHeadingTextView.isVisible = true
   }
 
   private fun showConfirmExitDialog() {

--- a/app/src/main/java/dev/sasikanth/pinnit/notifications/NotificationsScreen.kt
+++ b/app/src/main/java/dev/sasikanth/pinnit/notifications/NotificationsScreen.kt
@@ -35,7 +35,6 @@ import dev.sasikanth.pinnit.notifications.adapter.NotificationsListAdapter
 import dev.sasikanth.pinnit.options.OptionsBottomSheet
 import dev.sasikanth.pinnit.utils.UserClock
 import dev.sasikanth.pinnit.utils.UtcClock
-import kotlinx.android.synthetic.main.activity_main.*
 import kotlinx.android.synthetic.main.fragment_notifications.*
 import java.time.format.DateTimeFormatter
 import javax.inject.Inject
@@ -97,6 +96,8 @@ class NotificationsScreen : Fragment(R.layout.fragment_notifications), Notificat
 
     postponeEnterTransition()
 
+    toolbar.applySystemWindowInsetsToPadding(top = true, left = true, right = true)
+
     adapter = NotificationsListAdapter(
       utcClock = utcClock,
       userClock = userClock,
@@ -125,22 +126,17 @@ class NotificationsScreen : Fragment(R.layout.fragment_notifications), Notificat
       ::viewEffectsHandler,
       { pausedViewEffects -> pausedViewEffects.forEach(::viewEffectsHandler) })
 
-    requireActivity().bottomBar.setNavigationIcon(R.drawable.ic_pinnit_dark_mode)
-    requireActivity().bottomBar.setContentActionEnabled(true)
-    requireActivity().bottomBar.setContentActionText(R.string.create)
-    requireActivity().bottomBar.setActionIcon(R.drawable.ic_pinnit_about)
-
-    requireActivity().bottomBar.setNavigationOnClickListener {
+    bottomBar.setNavigationOnClickListener {
       OptionsBottomSheet.show(requireActivity().supportFragmentManager)
     }
-    requireActivity().bottomBar.setContentActionOnClickListener {
+    bottomBar.setContentActionOnClickListener {
       openNotificationEditor(
         notification = null,
         navigatorExtras = null,
         editorTransition = SharedAxis
       )
     }
-    requireActivity().bottomBar.setActionOnClickListener {
+    bottomBar.setActionOnClickListener {
       showAbout()
     }
   }
@@ -149,7 +145,7 @@ class NotificationsScreen : Fragment(R.layout.fragment_notifications), Notificat
     when (viewEffect) {
       is UndoNotificationDeleteViewEffect -> {
         Snackbar.make(notificationsRoot, R.string.notification_deleted, Snackbar.LENGTH_LONG)
-          .setAnchorView(requireActivity().bottomBar)
+          .setAnchorView(bottomBar)
           .setAction(R.string.undo) {
             viewModel.dispatchEvent(UndoNotificationDelete(viewEffect.notificationUuid))
           }

--- a/app/src/main/java/dev/sasikanth/pinnit/notifications/adapter/NotificationsListAdapter.kt
+++ b/app/src/main/java/dev/sasikanth/pinnit/notifications/adapter/NotificationsListAdapter.kt
@@ -18,11 +18,10 @@ import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.circularreveal.CircularRevealCompat
 import dev.sasikanth.pinnit.R
 import dev.sasikanth.pinnit.data.PinnitNotification
+import dev.sasikanth.pinnit.databinding.NotificationsListItemBinding
 import dev.sasikanth.pinnit.utils.UserClock
 import dev.sasikanth.pinnit.utils.UtcClock
 import dev.sasikanth.pinnit.utils.resolveColor
-import kotlinx.android.extensions.LayoutContainer
-import kotlinx.android.synthetic.main.notifications_list_item.*
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -43,13 +42,15 @@ class NotificationsListAdapter(
 
   override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
     val context = parent.context
-    val view = LayoutInflater.from(context).inflate(R.layout.notifications_list_item, parent, false)
-    return NotificationViewHolder(view).apply {
-      togglePinIcon.setOnClickListener {
+    val layoutInflater = LayoutInflater.from(context)
+    val binding = NotificationsListItemBinding.inflate(layoutInflater, parent, false)
+
+    return NotificationViewHolder(binding).apply {
+      binding.togglePinIcon.setOnClickListener {
         onToggleNotificationPinClicked(currentList[adapterPosition])
       }
 
-      scheduleButton.setOnClickListener {
+      binding.scheduleButton.setOnClickListener {
         val popupMenu = PopupMenu(context, it, Gravity.START)
         popupMenu.inflate(R.menu.notification_schedule)
         popupMenu.setOnMenuItemClickListener { item ->
@@ -88,7 +89,9 @@ class NotificationsListAdapter(
     return currentList[position].uuid.hashCode().toLong()
   }
 
-  inner class NotificationViewHolder(override val containerView: View) : RecyclerView.ViewHolder(containerView), LayoutContainer {
+  inner class NotificationViewHolder(
+    private val binding: NotificationsListItemBinding
+  ) : RecyclerView.ViewHolder(binding.root) {
 
     private val context = itemView.context
 
@@ -98,25 +101,25 @@ class NotificationsListAdapter(
     fun bind(notification: PinnitNotification) {
       itemView.tag = notification
 
-      titleTextView.text = notification.title
-      contentTextView.text = notification.content
-      contentTextView.isVisible = notification.content.isNullOrBlank().not()
+      binding.titleTextView.text = notification.title
+      binding.contentTextView.text = notification.content
+      binding.contentTextView.isVisible = notification.content.isNullOrBlank().not()
 
-      timeStamp.text = DateUtils.getRelativeTimeSpanString(
+      binding.timeStamp.text = DateUtils.getRelativeTimeSpanString(
         notification.updatedAt.toEpochMilli(),
         now.toEpochMilli(),
         SECOND_IN_MILLIS,
         FORMAT_ABBREV_RELATIVE
       )
 
-      togglePinIcon.isChecked = notification.isPinned
-      notificationRevealLayout.isVisible = notification.isPinned
+      binding.togglePinIcon.isChecked = notification.isPinned
+      binding.notificationRevealLayout.isVisible = notification.isPinned
       if (notification.isPinned) {
         colorsForNotificationPinned()
       } else {
         colorsForNotificationUnPinned()
       }
-      divider.isSelected = notification.isPinned
+      binding.divider.isSelected = notification.isPinned
 
       renderScheduleButton(notification)
 
@@ -127,7 +130,7 @@ class NotificationsListAdapter(
       val userCurrentDateTime = LocalDateTime.now(userClock)
       val schedule = notification.schedule
 
-      scheduleButton.isVisible = schedule != null
+      binding.scheduleButton.isVisible = schedule != null
       if (schedule == null) return
 
       val scheduleDateTime = schedule.scheduleDate!!.atTime(schedule.scheduleTime!!)
@@ -142,14 +145,14 @@ class NotificationsListAdapter(
 
       // Reproducing steps: Pin a past note with schedule, close the app, open the app, unpin note
       // with `state_enabled` in CSL the icon color is not set to disabled color.
-      scheduleButton.isSelected = isInFuture
-      scheduleButton.isEnabled = isInFuture
+      binding.scheduleButton.isSelected = isInFuture
+      binding.scheduleButton.isEnabled = isInFuture
 
       if (isPinned && !scheduleIsRepeatable) {
-        scheduleButton.isVisible = false
+        binding.scheduleButton.isVisible = false
       }
 
-      scheduleButton.text = scheduleButtonText(scheduleDateTime, userCurrentDateTime)
+      binding.scheduleButton.text = scheduleButtonText(scheduleDateTime, userCurrentDateTime)
     }
 
     private fun scheduleButtonText(
@@ -189,39 +192,39 @@ class NotificationsListAdapter(
     }
 
     private fun getRevealCx(): Float {
-      return (togglePinIcon.left + togglePinIcon.right) / 2f
+      return (binding.togglePinIcon.left + binding.togglePinIcon.right) / 2f
     }
 
     private fun getRevealCy(): Float {
-      return (togglePinIcon.top + togglePinIcon.bottom) / 2f
+      return (binding.togglePinIcon.top + binding.togglePinIcon.bottom) / 2f
     }
 
     private fun colorsForNotificationUnPinned() {
-      appIcon.imageTintList = ColorStateList.valueOf(context.resolveColor(attrRes = R.attr.colorSecondary))
-      appName.setTextColor(context.resolveColor(attrRes = R.attr.colorSecondary))
-      infoSeparator.setTextColor(context.resolveColor(attrRes = R.attr.colorOnBackgroundVariant))
-      timeStamp.setTextColor(context.resolveColor(attrRes = R.attr.colorOnBackgroundVariant))
+      binding.appIcon.imageTintList = ColorStateList.valueOf(context.resolveColor(attrRes = R.attr.colorSecondary))
+      binding.appName.setTextColor(context.resolveColor(attrRes = R.attr.colorSecondary))
+      binding.infoSeparator.setTextColor(context.resolveColor(attrRes = R.attr.colorOnBackgroundVariant))
+      binding.timeStamp.setTextColor(context.resolveColor(attrRes = R.attr.colorOnBackgroundVariant))
 
-      titleTextView.setTextColor(context.resolveColor(attrRes = R.attr.colorOnBackground))
-      contentTextView.setTextColor(context.resolveColor(attrRes = R.attr.colorOnBackgroundVariant))
+      binding.titleTextView.setTextColor(context.resolveColor(attrRes = R.attr.colorOnBackground))
+      binding.contentTextView.setTextColor(context.resolveColor(attrRes = R.attr.colorOnBackgroundVariant))
 
-      scheduleButton.strokeColor = ContextCompat.getColorStateList(context, R.color.schedule_indicator_stroke_state)
-      scheduleButton.setTextColor(ContextCompat.getColorStateList(context, R.color.schedule_indicator_text_state))
-      scheduleButton.iconTint = ContextCompat.getColorStateList(context, R.color.schedule_indicator_icon_state)
+      binding.scheduleButton.strokeColor = ContextCompat.getColorStateList(context, R.color.schedule_indicator_stroke_state)
+      binding.scheduleButton.setTextColor(ContextCompat.getColorStateList(context, R.color.schedule_indicator_text_state))
+      binding.scheduleButton.iconTint = ContextCompat.getColorStateList(context, R.color.schedule_indicator_icon_state)
     }
 
     private fun colorsForNotificationPinned() {
-      appIcon.imageTintList = ColorStateList.valueOf(context.resolveColor(attrRes = R.attr.colorOnPrimaryVariant))
-      appName.setTextColor(context.resolveColor(attrRes = R.attr.colorOnPrimaryVariant))
-      infoSeparator.setTextColor(context.resolveColor(attrRes = R.attr.colorOnPrimaryVariant))
-      timeStamp.setTextColor(context.resolveColor(attrRes = R.attr.colorOnPrimaryVariant))
+      binding.appIcon.imageTintList = ColorStateList.valueOf(context.resolveColor(attrRes = R.attr.colorOnPrimaryVariant))
+      binding.appName.setTextColor(context.resolveColor(attrRes = R.attr.colorOnPrimaryVariant))
+      binding.infoSeparator.setTextColor(context.resolveColor(attrRes = R.attr.colorOnPrimaryVariant))
+      binding.timeStamp.setTextColor(context.resolveColor(attrRes = R.attr.colorOnPrimaryVariant))
 
-      titleTextView.setTextColor(context.resolveColor(attrRes = R.attr.colorOnPrimary))
-      contentTextView.setTextColor(context.resolveColor(attrRes = R.attr.colorOnPrimaryVariant))
+      binding.titleTextView.setTextColor(context.resolveColor(attrRes = R.attr.colorOnPrimary))
+      binding.contentTextView.setTextColor(context.resolveColor(attrRes = R.attr.colorOnPrimaryVariant))
 
-      scheduleButton.strokeColor = ColorStateList.valueOf(context.resolveColor(attrRes = R.attr.colorOnPrimary))
-      scheduleButton.setTextColor(context.resolveColor(attrRes = R.attr.colorOnPrimary))
-      scheduleButton.iconTint = ColorStateList.valueOf(context.resolveColor(attrRes = R.attr.colorOnPrimary))
+      binding.scheduleButton.strokeColor = ColorStateList.valueOf(context.resolveColor(attrRes = R.attr.colorOnPrimary))
+      binding.scheduleButton.setTextColor(context.resolveColor(attrRes = R.attr.colorOnPrimary))
+      binding.scheduleButton.iconTint = ColorStateList.valueOf(context.resolveColor(attrRes = R.attr.colorOnPrimary))
     }
 
     fun animateReveal(
@@ -241,7 +244,7 @@ class NotificationsListAdapter(
       val endRadius = if (newPinStatus) viewRadius else 0f
 
       val anim = CircularRevealCompat.createCircularReveal(
-        notificationRevealLayout,
+        binding.notificationRevealLayout,
         cx,
         cy,
         startRadius,
@@ -253,8 +256,8 @@ class NotificationsListAdapter(
         anim.interpolator = fastOutSlowInInterpolator
         anim.addListener(
           onStart = {
-            togglePinIcon.isChecked = true
-            notificationRevealLayout.isVisible = true
+            binding.togglePinIcon.isChecked = true
+            binding.notificationRevealLayout.isVisible = true
           },
           onEnd = {
             colorsForNotificationPinned()
@@ -266,11 +269,11 @@ class NotificationsListAdapter(
         anim.interpolator = accelerateInterpolator
         anim.addListener(
           onStart = {
-            notificationRevealLayout.isVisible = true
+            binding.notificationRevealLayout.isVisible = true
           },
           onEnd = {
-            notificationRevealLayout.isVisible = false
-            togglePinIcon.isChecked = false
+            binding.notificationRevealLayout.isVisible = false
+            binding.togglePinIcon.isChecked = false
             colorsForNotificationUnPinned()
             dispatchAnimationFinished()
           }

--- a/app/src/main/java/dev/sasikanth/pinnit/oemwarning/OemWarningDialog.kt
+++ b/app/src/main/java/dev/sasikanth/pinnit/oemwarning/OemWarningDialog.kt
@@ -12,8 +12,7 @@ import android.view.ViewGroup
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.FragmentManager
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import dev.sasikanth.pinnit.R
-import kotlinx.android.synthetic.main.pinnit_oem_warning_dialog.*
+import dev.sasikanth.pinnit.databinding.PinnitOemWarningDialogBinding
 
 class OemWarningDialog : DialogFragment() {
 
@@ -27,30 +26,33 @@ class OemWarningDialog : DialogFragment() {
     }
   }
 
-  private var dialogLayout: View? = null
+  private var _binding: PinnitOemWarningDialogBinding? = null
+  private val binding get() = _binding!!
 
   @SuppressLint("InflateParams")
   override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-    dialogLayout = LayoutInflater.from(requireContext()).inflate(R.layout.pinnit_oem_warning_dialog, null)
+    val layoutInflater = LayoutInflater.from(requireContext())
+    _binding = PinnitOemWarningDialogBinding.inflate(layoutInflater, null, false)
+
     return MaterialAlertDialogBuilder(requireContext())
-      .setView(dialogLayout)
+      .setView(binding.root)
       .create()
   }
 
-  override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-    return dialogLayout
+  override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+    return binding.root
   }
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
-    showInstructionsButton?.setOnClickListener {
+    binding.showInstructionsButton.setOnClickListener {
       showInstructions()
       dismiss()
     }
   }
 
   override fun onDestroyView() {
-    dialogLayout = null
+    _binding = null
     super.onDestroyView()
   }
 

--- a/app/src/main/java/dev/sasikanth/pinnit/options/OptionsBottomSheet.kt
+++ b/app/src/main/java/dev/sasikanth/pinnit/options/OptionsBottomSheet.kt
@@ -12,9 +12,9 @@ import androidx.lifecycle.lifecycleScope
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import dev.sasikanth.pinnit.R
 import dev.sasikanth.pinnit.data.preferences.AppPreferences
+import dev.sasikanth.pinnit.databinding.ThemeSelectionSheetBinding
 import dev.sasikanth.pinnit.di.injector
 import dev.sasikanth.pinnit.utils.DispatcherProvider
-import kotlinx.android.synthetic.main.theme_selection_sheet.*
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
@@ -40,13 +40,17 @@ class OptionsBottomSheet : BottomSheetDialogFragment() {
     }
   }
 
+  private var _binding: ThemeSelectionSheetBinding? = null
+  private val binding get() = _binding!!
+
   override fun onAttach(context: Context) {
     super.onAttach(context)
     injector.inject(this)
   }
 
   override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-    return inflater.inflate(R.layout.theme_selection_sheet, container, false)
+    _binding = ThemeSelectionSheetBinding.inflate(layoutInflater, container, false)
+    return _binding?.root
   }
 
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -58,7 +62,7 @@ class OptionsBottomSheet : BottomSheetDialogFragment() {
       }
       checkThemeSelection(theme)
 
-      themeButtonGroup
+      binding.themeButtonGroup
         .buttonCheckedChanges()
         .filter { it.checked }
         .map { it.checkedId }
@@ -66,13 +70,20 @@ class OptionsBottomSheet : BottomSheetDialogFragment() {
     }
   }
 
+  override fun onDestroyView() {
+    _binding = null
+    super.onDestroyView()
+  }
+
   private fun checkThemeSelection(theme: AppPreferences.Theme) {
-    when (theme) {
-      AppPreferences.Theme.AUTO -> themeButtonGroup.check(R.id.darkModeAuto)
-      AppPreferences.Theme.LIGHT -> themeButtonGroup.check(R.id.darkModeOff)
-      AppPreferences.Theme.DARK -> themeButtonGroup.check(R.id.darkModeOn)
-      else -> themeButtonGroup.check(R.id.darkModeAuto)
+    val id = when (theme) {
+      AppPreferences.Theme.AUTO -> R.id.darkModeAuto
+      AppPreferences.Theme.LIGHT -> R.id.darkModeOff
+      AppPreferences.Theme.DARK -> R.id.darkModeOn
+      else -> R.id.darkModeAuto
     }
+
+    binding.themeButtonGroup.check(id)
   }
 
   private suspend fun updateTheme(@IdRes checkedId: Int) {

--- a/app/src/main/java/dev/sasikanth/pinnit/qspopup/QsPopupActivity.kt
+++ b/app/src/main/java/dev/sasikanth/pinnit/qspopup/QsPopupActivity.kt
@@ -16,6 +16,7 @@ import com.spotify.mobius.functions.Consumer
 import dev.sasikanth.pinnit.R
 import dev.sasikanth.pinnit.activity.MainActivity
 import dev.sasikanth.pinnit.data.PinnitNotification
+import dev.sasikanth.pinnit.databinding.ActivityQsPopupBinding
 import dev.sasikanth.pinnit.di.DateTimeFormat
 import dev.sasikanth.pinnit.di.injector
 import dev.sasikanth.pinnit.editor.EditorScreenArgs
@@ -24,7 +25,6 @@ import dev.sasikanth.pinnit.notifications.adapter.NotificationPinItemAnimator
 import dev.sasikanth.pinnit.notifications.adapter.NotificationsListAdapter
 import dev.sasikanth.pinnit.utils.UserClock
 import dev.sasikanth.pinnit.utils.UtcClock
-import kotlinx.android.synthetic.main.activity_qs_popup.*
 import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
@@ -33,7 +33,7 @@ import javax.inject.Inject
  * clicked. The reason why I didn't use an actual dialog is because it's not
  * properly following the app theme (day/night).
  */
-class QsPopupActivity : AppCompatActivity(R.layout.activity_qs_popup), QsPopupUi {
+class QsPopupActivity : AppCompatActivity(), QsPopupUi {
 
   @Inject
   lateinit var effectHandler: QsPopupEffectHandler.Factory
@@ -73,10 +73,14 @@ class QsPopupActivity : AppCompatActivity(R.layout.activity_qs_popup), QsPopupUi
   }
 
   private lateinit var adapter: NotificationsListAdapter
+  private lateinit var binding: ActivityQsPopupBinding
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     injector.inject(this)
+
+    binding = ActivityQsPopupBinding.inflate(layoutInflater)
+    setContentView(binding.root)
 
     adapter = NotificationsListAdapter(
       utcClock = utcClock,
@@ -88,8 +92,8 @@ class QsPopupActivity : AppCompatActivity(R.layout.activity_qs_popup), QsPopupUi
       onEditNotificationScheduleClicked = ::onEditNotificationScheduleClicked,
       onRemoveNotificationScheduleClicked = ::onRemoveNotificationScheduleClicked
     )
-    qsPopupNotificationsRecyclerView.adapter = adapter
-    qsPopupNotificationsRecyclerView.itemAnimator = NotificationPinItemAnimator()
+    binding.qsPopupNotificationsRecyclerView.adapter = adapter
+    binding.qsPopupNotificationsRecyclerView.itemAnimator = NotificationPinItemAnimator()
 
     viewModel.models.observe(this, { model ->
       uiRender.render(model)
@@ -103,16 +107,16 @@ class QsPopupActivity : AppCompatActivity(R.layout.activity_qs_popup), QsPopupUi
       }
     })
 
-    backgroundRoot.setOnClickListener { finish() }
+    binding.backgroundRoot.setOnClickListener { finish() }
 
-    openAppButton.setOnClickListener {
+    binding.openAppButton.setOnClickListener {
       Intent(this, MainActivity::class.java).also {
         it.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
         startActivity(it)
       }
     }
 
-    createNotificationButton.setOnClickListener {
+    binding.createNotificationButton.setOnClickListener {
       openNotificationEditorView(notification = null)
     }
   }
@@ -136,22 +140,22 @@ class QsPopupActivity : AppCompatActivity(R.layout.activity_qs_popup), QsPopupUi
 
   override fun showNotifications(notifications: List<PinnitNotification>) {
     adapter.submitList(notifications)
-    qsPopupNotificationsRecyclerView.isVisible = true
+    binding.qsPopupNotificationsRecyclerView.isVisible = true
   }
 
   override fun hideNotifications() {
     adapter.submitList(null)
-    qsPopupNotificationsRecyclerView.isGone = true
+    binding.qsPopupNotificationsRecyclerView.isGone = true
   }
 
   override fun showNotificationsEmptyError() {
-    noNotificationsTextView.isVisible = true
-    noNotificationsImageView.isVisible = true
+    binding.noNotificationsTextView.isVisible = true
+    binding.noNotificationsImageView.isVisible = true
   }
 
   override fun hideNotificationsEmptyError() {
-    noNotificationsTextView.isGone = true
-    noNotificationsImageView.isGone = true
+    binding.noNotificationsTextView.isGone = true
+    binding.noNotificationsImageView.isGone = true
   }
 
   private fun onToggleNotificationPinClicked(notification: PinnitNotification) {

--- a/app/src/main/java/dev/sasikanth/pinnit/widgets/PinnitBottomBar.kt
+++ b/app/src/main/java/dev/sasikanth/pinnit/widgets/PinnitBottomBar.kt
@@ -2,38 +2,41 @@ package dev.sasikanth.pinnit.widgets
 
 import android.content.Context
 import android.util.AttributeSet
+import android.view.LayoutInflater
 import android.view.View
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.res.getResourceIdOrThrow
+import androidx.core.content.res.use
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import dev.chrisbanes.insetter.applySystemWindowInsetsToPadding
 import dev.sasikanth.pinnit.R
+import dev.sasikanth.pinnit.databinding.PinnitBottomBarBinding
 import dev.sasikanth.pinnit.utils.dp
-import kotlinx.android.synthetic.main.pinnit_bottom_bar.view.*
 
-class PinnitBottomBar @JvmOverloads
-constructor(
+class PinnitBottomBar @JvmOverloads constructor(
   context: Context,
   attrs: AttributeSet? = null,
   defStyleAttr: Int = 0
 ) : ConstraintLayout(context, attrs, defStyleAttr) {
 
-  init {
-    inflate(context, R.layout.pinnit_bottom_bar, this)
+  private var _binding: PinnitBottomBarBinding? = null
+  private val binding get() = _binding!!
 
-    context.theme.obtainStyledAttributes(attrs, R.styleable.PinnitBottomBar, defStyleAttr, 0).apply {
-      val mNavigationIcon = getResourceIdOrThrow(R.styleable.PinnitBottomBar_navigationIcon)
-      val mContentActionText = getResourceIdOrThrow(R.styleable.PinnitBottomBar_contentActionText)
-      val mActionIcon = getResourceIdOrThrow(R.styleable.PinnitBottomBar_actionIcon)
+  init {
+    val layoutInflater = LayoutInflater.from(context)
+    _binding = PinnitBottomBarBinding.inflate(layoutInflater, this)
+
+    context.theme.obtainStyledAttributes(attrs, R.styleable.PinnitBottomBar, defStyleAttr, 0).use { typedArray ->
+      val mNavigationIcon = typedArray.getResourceIdOrThrow(R.styleable.PinnitBottomBar_navigationIcon)
+      val mContentActionText = typedArray.getResourceIdOrThrow(R.styleable.PinnitBottomBar_contentActionText)
+      val mActionIcon = typedArray.getResourceIdOrThrow(R.styleable.PinnitBottomBar_actionIcon)
 
       setNavigationIcon(mNavigationIcon)
       setContentActionText(mContentActionText)
       setActionIcon(mActionIcon)
-
-      recycle()
     }
 
     // Adding Z-axis so that the snackbar will start
@@ -42,55 +45,60 @@ constructor(
     applySystemWindowInsetsToPadding(bottom = true, left = true, right = true)
   }
 
+  override fun onDetachedFromWindow() {
+    _binding = null
+    super.onDetachedFromWindow()
+  }
+
   fun setNavigationIcon(@DrawableRes navigationIcon: Int?) {
     if (navigationIcon != null) {
-      this.navigationIcon.isVisible = true
-      this.navigationIcon.setImageResource(navigationIcon)
+      binding.navigationIcon.isVisible = true
+      binding.navigationIcon.setImageResource(navigationIcon)
     } else {
-      this.navigationIcon.isGone = true
+      binding.navigationIcon.isGone = true
     }
   }
 
   fun setContentActionText(@StringRes contentActionTextRes: Int?) {
     if (contentActionTextRes != null) {
-      this.contentActionButton.isVisible = true
-      this.contentActionButton.setText(contentActionTextRes)
+      binding.contentActionButton.isVisible = true
+      binding.contentActionButton.setText(contentActionTextRes)
     } else {
-      this.contentActionButton.isGone = true
+      binding.contentActionButton.isGone = true
     }
   }
 
   fun setContentActionText(contentActionText: String?) {
     if (contentActionText != null) {
-      this.contentActionButton.isVisible = true
-      this.contentActionButton.text = contentActionText
+      binding.contentActionButton.isVisible = true
+      binding.contentActionButton.text = contentActionText
     } else {
-      this.contentActionButton.isGone = true
+      binding.contentActionButton.isGone = true
     }
   }
 
   fun setActionIcon(@DrawableRes actionIcon: Int?) {
     if (actionIcon != null) {
-      this.actionIcon.isVisible = true
-      this.actionIcon.setImageResource(actionIcon)
+      binding.actionIcon.isVisible = true
+      binding.actionIcon.setImageResource(actionIcon)
     } else {
-      this.actionIcon.isGone = true
+      binding.actionIcon.isGone = true
     }
   }
 
   fun setContentActionEnabled(isEnabled: Boolean) {
-    contentActionButton.isEnabled = isEnabled
+    binding.contentActionButton.isEnabled = isEnabled
   }
 
   fun setNavigationOnClickListener(listener: ((View) -> Unit)?) {
-    navigationIcon.setOnClickListener(listener)
+    binding.navigationIcon.setOnClickListener(listener)
   }
 
   fun setContentActionOnClickListener(listener: ((View) -> Unit)?) {
-    contentActionButton.setOnClickListener(listener)
+    binding.contentActionButton.setOnClickListener(listener)
   }
 
   fun setActionOnClickListener(listener: ((View) -> Unit)?) {
-    actionIcon.setOnClickListener(listener)
+    binding.actionIcon.setOnClickListener(listener)
   }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -7,58 +7,12 @@
   android:layout_height="match_parent"
   tools:context=".activity.MainActivity">
 
-  <com.google.android.material.appbar.AppBarLayout
-    android:id="@+id/appBarLayout"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:background="?android:attr/colorBackground"
-    app:elevation="0dp"
-    app:layout_constraintTop_toTopOf="parent">
-
-    <com.google.android.material.appbar.MaterialToolbar
-      android:id="@+id/toolbar"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      app:layout_scrollFlags="enterAlwaysCollapsed|scroll"
-      app:title="@null">
-
-      <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/toolbarTitleTextView"
-        style="@style/TextStyle.Pinnit.Headline6"
-        android:layout_width="match_parent"
-        android:layout_height="?attr/actionBarSize"
-        android:layout_marginEnd="16dp"
-        android:gravity="center"
-        tools:text="@string/app_name" />
-
-    </com.google.android.material.appbar.MaterialToolbar>
-
-    <View
-      android:layout_width="match_parent"
-      android:layout_height="1dp"
-      android:layout_marginTop="-1dp"
-      android:background="@drawable/divider" />
-
-  </com.google.android.material.appbar.AppBarLayout>
-
   <androidx.fragment.app.FragmentContainerView
     android:id="@+id/nav_host_fragment_container"
     android:name="androidx.navigation.fragment.NavHostFragment"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     app:defaultNavHost="true"
-    app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior"
     app:navGraph="@navigation/main_nav_graph" />
-
-  <dev.sasikanth.pinnit.widgets.PinnitBottomBar
-    android:id="@+id/bottomBar"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:layout_gravity="bottom"
-    android:animateLayoutChanges="true"
-    android:background="?attr/colorSurface"
-    app:actionIcon="@drawable/ic_pinnit_about"
-    app:contentActionText="@string/create"
-    app:navigationIcon="@drawable/ic_pinnit_dark_mode" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_notification_editor.xml
+++ b/app/src/main/res/layout/fragment_notification_editor.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
   android:id="@+id/editorRoot"
@@ -8,13 +8,48 @@
   android:background="?android:attr/colorBackground"
   tools:context=".editor.EditorScreen">
 
+  <com.google.android.material.appbar.AppBarLayout
+    android:id="@+id/appBarLayout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?android:attr/colorBackground"
+    app:elevation="0dp"
+    app:layout_constraintTop_toTopOf="parent">
+
+    <com.google.android.material.appbar.MaterialToolbar
+      android:id="@+id/toolbar"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      app:layout_scrollFlags="enterAlwaysCollapsed|scroll"
+      app:title="@null">
+
+      <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/toolbarTitleTextView"
+        style="@style/TextStyle.Pinnit.Headline6"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:layout_marginEnd="16dp"
+        android:gravity="center"
+        tools:text="@string/app_name" />
+
+    </com.google.android.material.appbar.MaterialToolbar>
+
+    <View
+      android:layout_width="match_parent"
+      android:layout_height="1dp"
+      android:layout_marginTop="-1dp"
+      android:background="@drawable/divider" />
+
+  </com.google.android.material.appbar.AppBarLayout>
+
   <androidx.core.widget.NestedScrollView
     android:id="@+id/editorScrollView"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:clipChildren="false"
     android:clipToPadding="false"
-    android:paddingBottom="88dp">
+    android:paddingBottom="88dp"
+    app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior">
 
     <androidx.constraintlayout.widget.ConstraintLayout
       android:layout_width="match_parent"
@@ -145,4 +180,15 @@
 
   </androidx.core.widget.NestedScrollView>
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+  <dev.sasikanth.pinnit.widgets.PinnitBottomBar
+    android:id="@+id/bottomBar"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_gravity="bottom"
+    android:animateLayoutChanges="true"
+    android:background="?attr/colorSurface"
+    app:actionIcon="@drawable/ic_pinnit_delete"
+    app:contentActionText="@string/save_and_pin"
+    app:navigationIcon="@drawable/ic_arrow_back" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_notifications.xml
+++ b/app/src/main/res/layout/fragment_notifications.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   xmlns:tools="http://schemas.android.com/tools"
   android:id="@+id/notificationsRoot"
@@ -7,48 +7,100 @@
   android:layout_height="match_parent"
   tools:context=".notifications.NotificationsScreen">
 
-  <ImageView
-    android:id="@+id/noNotificationsImageView"
-    android:layout_width="80dp"
-    android:layout_height="80dp"
-    android:contentDescription="@null"
-    android:src="@drawable/illustration_pinnit_pin"
-    android:visibility="gone"
-    app:layout_constraintBottom_toTopOf="@id/noNotificationsTextView"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toTopOf="parent"
-    app:layout_constraintVertical_chainStyle="packed"
-    tools:visibility="visible" />
-
-  <com.google.android.material.textview.MaterialTextView
-    android:id="@+id/noNotificationsTextView"
-    style="@style/TextStyle.Pinnit.Headline6"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_marginStart="72dp"
-    android:layout_marginTop="16dp"
-    android:layout_marginEnd="72dp"
-    android:layout_marginBottom="88dp"
-    android:text="@string/no_notifications"
-    android:visibility="gone"
-    app:layout_constraintBottom_toBottomOf="parent"
-    app:layout_constraintEnd_toEndOf="parent"
-    app:layout_constraintStart_toStartOf="parent"
-    app:layout_constraintTop_toBottomOf="@id/noNotificationsImageView"
-    tools:visibility="visible" />
-
-  <androidx.recyclerview.widget.RecyclerView
-    android:id="@+id/notificationsRecyclerView"
+  <com.google.android.material.appbar.AppBarLayout
+    android:id="@+id/appBarLayout"
     android:layout_width="match_parent"
-    android:layout_height="0dp"
-    android:clipToPadding="false"
-    android:paddingBottom="88dp"
-    android:visibility="gone"
-    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-    app:layout_constraintBottom_toBottomOf="parent"
-    app:layout_constraintTop_toTopOf="parent"
-    tools:listitem="@layout/notifications_list_item"
-    tools:visibility="visible" />
+    android:layout_height="wrap_content"
+    android:background="?android:attr/colorBackground"
+    app:elevation="0dp"
+    app:layout_constraintTop_toTopOf="parent">
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    <com.google.android.material.appbar.MaterialToolbar
+      android:id="@+id/toolbar"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      app:layout_scrollFlags="enterAlwaysCollapsed|scroll"
+      app:title="@null">
+
+      <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/toolbarTitleTextView"
+        style="@style/TextStyle.Pinnit.Headline6"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:layout_marginEnd="16dp"
+        android:gravity="center"
+        android:text="@string/toolbar_title_notifications" />
+
+    </com.google.android.material.appbar.MaterialToolbar>
+
+    <View
+      android:layout_width="match_parent"
+      android:layout_height="1dp"
+      android:layout_marginTop="-1dp"
+      android:background="@drawable/divider" />
+
+  </com.google.android.material.appbar.AppBarLayout>
+
+  <androidx.constraintlayout.widget.ConstraintLayout
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    app:layout_behavior="com.google.android.material.appbar.AppBarLayout$ScrollingViewBehavior">
+
+    <ImageView
+      android:id="@+id/noNotificationsImageView"
+      android:layout_width="80dp"
+      android:layout_height="80dp"
+      android:contentDescription="@null"
+      android:src="@drawable/illustration_pinnit_pin"
+      android:visibility="gone"
+      app:layout_constraintBottom_toTopOf="@id/noNotificationsTextView"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent"
+      app:layout_constraintVertical_chainStyle="packed"
+      tools:visibility="visible" />
+
+    <com.google.android.material.textview.MaterialTextView
+      android:id="@+id/noNotificationsTextView"
+      style="@style/TextStyle.Pinnit.Headline6"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginStart="72dp"
+      android:layout_marginTop="16dp"
+      android:layout_marginEnd="72dp"
+      android:layout_marginBottom="88dp"
+      android:text="@string/no_notifications"
+      android:visibility="gone"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@id/noNotificationsImageView"
+      tools:visibility="visible" />
+
+    <androidx.recyclerview.widget.RecyclerView
+      android:id="@+id/notificationsRecyclerView"
+      android:layout_width="match_parent"
+      android:layout_height="0dp"
+      android:clipToPadding="false"
+      android:paddingBottom="88dp"
+      android:visibility="gone"
+      app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintTop_toTopOf="parent"
+      tools:listitem="@layout/notifications_list_item"
+      tools:visibility="visible" />
+
+  </androidx.constraintlayout.widget.ConstraintLayout>
+
+  <dev.sasikanth.pinnit.widgets.PinnitBottomBar
+    android:id="@+id/bottomBar"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_gravity="bottom"
+    android:animateLayoutChanges="true"
+    android:background="?attr/colorSurface"
+    app:actionIcon="@drawable/ic_pinnit_about"
+    app:contentActionText="@string/create"
+    app:navigationIcon="@drawable/ic_pinnit_dark_mode" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
- Enable view binding
- Use view binding in `SplashActivity`
- Use view binding in `MainActivity`
- Use view binding in `QsPopupActivity`
- Move `AppBarLayout` and `PinnitBottomBar` inside editor screen
- Move `AppBarLayout` and `PinnitBottomBar` inside notifications screen
- Remove nav destination listener in `MainActivity`
- Remove `AppBarLayout` & `PinnitBottomBar` from `activity_main`
- Use view binding in `EditorScreen`
- Use view binding in `NotificationsScreen`
- Use view binding in `NotificationsListAdapter`
- Use view binding in `PinnitBottomBar`
- Use view binding in `OemWarningDialog`
- Use view binding in `AboutBottomSheet`
- Use view binding in `OptionsBottomSheet`
