### PR TITLE
Bump SDK to target Android 12

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,12 +16,12 @@ kapt {
 }
 
 android {
-  compileSdkVersion 30
+  compileSdkVersion 31
 
   defaultConfig {
     applicationId "dev.sasikanth.pinnit"
     minSdkVersion 23
-    targetSdkVersion 30
+    targetSdkVersion 31
     versionCode rootProject.gitCommitCount
     versionName "1.2.0"
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,7 +15,9 @@
     android:theme="@style/Theme.Pinnit"
     tools:ignore="AllowBackup">
 
-    <activity android:name=".SplashActivity">
+    <activity
+      android:name=".SplashActivity"
+      android:exported="true">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
 
@@ -32,7 +34,9 @@
       android:theme="@style/Theme.Pinnit.Main"
       android:windowSoftInputMode="adjustResize" />
 
-    <activity android:name=".ShortcutReceiverActivity">
+    <activity
+      android:name=".ShortcutReceiverActivity"
+      android:exported="true">
       <intent-filter>
         <action android:name="android.intent.action.SEND" />
         <category android:name="android.intent.category.DEFAULT" />
@@ -45,20 +49,23 @@
       android:taskAffinity=""
       android:theme="@style/Theme.Pinnit.QsPopup" />
 
-    <activity android:name=".AppActionsReceiverActivity">
+    <activity
+      android:name=".AppActionsReceiverActivity"
+      android:exported="true">
       <intent-filter>
         <action android:name="android.intent.action.VIEW" />
         <category android:name="android.intent.category.DEFAULT" />
 
-        <data android:host="pinnit.app"
+        <data
+          android:host="pinnit.app"
           android:path="/"
-          android:scheme="app"/>
+          android:scheme="app" />
       </intent-filter>
     </activity>
 
     <service
       android:name=".background.services.NotificationsListener"
-      android:exported="false"
+      android:exported="true"
       android:permission="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE">
       <intent-filter>
         <action android:name="android.service.notification.NotificationListenerService" />
@@ -67,6 +74,7 @@
 
     <service
       android:name=".background.services.QsPopupService"
+      android:exported="true"
       android:icon="@drawable/ic_qs_app_icon"
       android:label="@string/app_name"
       android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
@@ -93,13 +101,17 @@
       </intent-filter>
     </receiver>
 
-    <receiver android:name=".background.receivers.BootCompletedReceiver">
+    <receiver
+      android:name=".background.receivers.BootCompletedReceiver"
+      android:exported="false">
       <intent-filter>
         <action android:name="android.intent.action.BOOT_COMPLETED" />
       </intent-filter>
     </receiver>
 
-    <receiver android:name=".background.receivers.AppUpdateReceiver">
+    <receiver
+      android:name=".background.receivers.AppUpdateReceiver"
+      android:exported="false">
       <intent-filter>
         <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
       </intent-filter>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -122,9 +122,15 @@
       android:resource="@xml/actions" />
 
     <provider
-      android:name="androidx.work.impl.WorkManagerInitializer"
-      android:authorities="${applicationId}.workmanager-init"
-      tools:node="remove" />
+      android:name="androidx.startup.InitializationProvider"
+      android:authorities="${applicationId}.androidx-startup"
+      android:exported="false"
+      tools:node="merge">
+      <meta-data
+        android:name="androidx.work.WorkManagerInitializer"
+        android:value="androidx.startup"
+        tools:node="remove" />
+    </provider>
 
   </application>
 

--- a/app/src/main/java/dev/sasikanth/pinnit/utils/notification/NotificationUtil.kt
+++ b/app/src/main/java/dev/sasikanth/pinnit/utils/notification/NotificationUtil.kt
@@ -99,7 +99,7 @@ class NotificationUtil @Inject constructor(
       context,
       notification.uuid.hashCode(),
       unpinIntent,
-      PendingIntent.FLAG_UPDATE_CURRENT
+      PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
     )
 
     val deleteIntent = Intent(context, DeleteNotificationReceiver::class.java).apply {
@@ -110,7 +110,7 @@ class NotificationUtil @Inject constructor(
       context,
       notification.uuid.hashCode(),
       deleteIntent,
-      PendingIntent.FLAG_UPDATE_CURRENT
+      PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
     )
 
     val builder = NotificationCompat.Builder(context, CHANNEL_ID)

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ buildscript {
       insetter             : '0.3.1',
       coreLibraryDesugaring: '1.1.1',
       betterLinkMovement   : '2.2.0',
-      workManager          : '2.5.0',
+      workManager          : '2.7.0',
       seekableAVD          : '1.0.0-alpha02',
       dataStore            : '1.0.0-alpha08',
       javaLite             : '3.11.0',

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
   ext.versions = [
       kotlin               : '1.5.21',
-      appCompat            : '1.2.0',
+      appCompat            : '1.3.1',
       coreKtx              : '1.3.2',
       constraintLayout     : '2.0.4',
       material             : '1.3.0',

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
       junit                : '4.13.2',
       extJunit             : '1.1.2',
       espressoCore         : '3.3.0',
-      navigation           : '2.3.4',
+      navigation           : '2.4.0-beta01',
       leakCanary           : '2.7',
       room                 : '2.3.0',
       coroutines           : '1.4.3',

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
       extJunit             : '1.1.2',
       espressoCore         : '3.3.0',
       navigation           : '2.3.4',
-      leakCanary           : '2.6',
+      leakCanary           : '2.7',
       room                 : '2.3.0',
       coroutines           : '1.4.3',
       truth                : '1.1.2',

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ buildscript {
       flowBinding          : '1.0.0',
       activity             : '1.3.1',
       fragment             : '1.3.6',
-      compose              : '1.0.1'
+      compose              : '1.0.4'
   ]
   repositories {
     google()

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
   ext.versions = [
-      kotlin               : '1.5.21',
+      kotlin               : '1.5.31',
       appCompat            : '1.3.1',
       coreKtx              : '1.3.2',
       constraintLayout     : '2.0.4',


### PR DESCRIPTION
- Bump SDK to target Android 12
- Export Activities, Services & Receiviers with intent filters in `AndroidManifest`
- Bump AppCompat to v1.3.1
- Bump Leak Canary to v2.7
- Bump WorkManager to v2.7.0
- Bump Kotlin to v1.5.31
- Bump Compose to v1.0.4
- Bump Navigation component to v2.4.0-beta01
- Use `FLAG_IMMUTABLE` flag when creating `PendingIntent`'s
